### PR TITLE
起動時アップデートチェック & SQLステートメント単位ハイライト

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2852,6 +2852,23 @@ fn main() {
                     }
                 });
             }
+            #[cfg(feature = "self-updater")]
+            {
+                let handle = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    // Delay to avoid slowing down app startup
+                    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+                    use tauri_plugin_updater::UpdaterExt;
+                    if let Ok(updater) = handle.updater() {
+                        if let Ok(Some(update)) = updater.check().await {
+                            let _ = handle.emit(
+                                "update-available",
+                                serde_json::json!({ "version": update.version }),
+                            );
+                        }
+                    }
+                });
+            }
             Ok(())
         })
         .on_menu_event(|app, event| {

--- a/ui/query.js
+++ b/ui/query.js
@@ -1852,6 +1852,36 @@ function addSqlTab(initialContent, tabNum) {
     editor.on("focus", function () { editorTouched = true; });
     editor.on("mousedown", function () { editorTouched = true; });
 
+    // Highlight the current SQL statement (delimited by ;)
+    let stmtHighlightLines = [];
+    function highlightCurrentStatement() {
+      // Clear previous highlights
+      stmtHighlightLines.forEach(function (lh) {
+        editor.removeLineClass(lh, "background", "cm-statement-highlight");
+      });
+      stmtHighlightLines = [];
+
+      const text = editor.getValue();
+      if (!text.trim()) return;
+      const cursor = editor.indexFromPos(editor.getCursor());
+      let start = 0;
+      const parts = text.split(";");
+      for (let i = 0; i < parts.length; i++) {
+        const end = start + parts[i].length;
+        if (cursor <= end) {
+          // Found the statement containing the cursor
+          const fromLine = editor.posFromIndex(start).line;
+          const toLine = editor.posFromIndex(end).line;
+          for (let ln = fromLine; ln <= toLine; ln++) {
+            stmtHighlightLines.push(editor.addLineClass(ln, "background", "cm-statement-highlight"));
+          }
+          break;
+        }
+        start = end + 1; // skip the ;
+      }
+    }
+    editor.on("cursorActivity", highlightCurrentStatement);
+
     editor.on("change", function () {
       scheduleDraftSave();
     });

--- a/ui/style.css
+++ b/ui/style.css
@@ -1415,6 +1415,11 @@ pre {
   color: var(--ink);
 }
 
+/* ── CodeMirror active statement highlight ── */
+.cm-statement-highlight {
+  background: rgba(59, 130, 246, 0.07);
+}
+
 /* ── CodeMirror active line ── */
 .CodeMirror-activeline-background {
   background: var(--hover-bg);
@@ -1438,6 +1443,9 @@ html.dark .CodeMirror-cursor {
 html.dark .CodeMirror-selected,
 html.dark .CodeMirror-focused .CodeMirror-selected {
   background: #2a3a5a;
+}
+html.dark .cm-statement-highlight {
+  background: rgba(59, 130, 246, 0.12);
 }
 html.dark .CodeMirror-activeline-background {
   background: #293754;


### PR DESCRIPTION
## Summary
- **#12**: 起動3秒後にバックグラウンドでアップデートチェックを実行。更新がある場合は既存のバナーUIで通知
- **#11**: SQLエディタで `;` 区切りのステートメント単位でカーソル位置の行全体をハイライト表示

## Changes
- `src-tauri/src/main.rs`: `.setup()` に `self-updater` feature guard 付きの自動チェックを追加（3秒遅延で起動を阻害しない）
- `ui/query.js`: `cursorActivity` イベントで現在のステートメント範囲を計算し `addLineClass` でハイライト
- `ui/style.css`: `.cm-statement-highlight` スタイル（ライト/ダーク両対応）

Closes #11, Closes #12

## Test plan
- [x] `cargo check` / `cargo clippy` 通過
- [x] アプリ起動時にアップデートバナーが表示されることを確認（更新がある場合）
- [x] SQLエディタで複数ステートメントを入力し、カーソル移動でハイライトが切り替わることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)