### PR TITLE
README の MS Store バッジ画像 URL を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 ## ダウンロード
 
 <a href="https://apps.microsoft.com/detail/9mvgmmcf47gj?hl=ja-JP&gl=JP">
-  <img src="https://get.microsoft.com/images/ja-jp%20dark.svg" width="200" alt="Microsoft Store から入手" />
+  <img src="https://get.microsoft.com/images/ja%20dark.svg" width="200" alt="Microsoft Store から入手" />
 </a>
 
 **[Microsoft Store](https://apps.microsoft.com/detail/9mvgmmcf47gj?hl=ja-JP&gl=JP) からのインストールを推奨します。** Microsoft による署名・自動更新・クリーンアンインストールに対応しています。


### PR DESCRIPTION
## Summary
- バッジ画像 URL を `ja-jp%20dark.svg` → `ja%20dark.svg` に修正
- get.microsoft.com の locale コードは \`ja-jp\` ではなく \`ja\`（前者は 404 で壊れた画像）

## Test plan
- [x] curl でレスポンス確認: \`200 https://get.microsoft.com/images/ja%20dark.svg\`
- [ ] マージ後 README で画像が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)